### PR TITLE
Fix lmdb pkgconf name: liblmdb -> lmdb

### DIFF
--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -59,7 +59,7 @@ fn main() {
         warn!("Building with `-fsanitize=fuzzer`.");
     }
 
-    if !pkg_config::find_library("liblmdb").is_ok() {
+    if !pkg_config::find_library("lmdb").is_ok() {
         let mut builder = cc::Build::new();
 
         builder


### PR DESCRIPTION
Fixes #9

build.rs currently never finds the system-provided lmdb library. pkgconf (or pkg-config) expects the name of the .pc file, not the name of the library file, and lmdb provides `lmdb.pc`, not `liblmdb.pc` (checked in Alpine Linux, Debian, Fedora).

This has been already proposed in the original project: https://github.com/danburkert/lmdb-rs/pull/53.
I’ve opened this pull request also in Mozilla’s fork: https://github.com/mozilla/lmdb-rs/pull/95.

Shouldn’t lmdb-sys also declare `links` in Cargo.toml?