### PR TITLE
Add feature to force vendoring of the provided lmdb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tempdir = "0.3"
 
 [features]
 default = []
+vendored = ["lmdb-rkv-sys/vendored"]
 with-asan = ["lmdb-rkv-sys/with-asan"]
 with-fuzzer = ["lmdb-rkv-sys/with-fuzzer"]
 with-fuzzer-no-link = ["lmdb-rkv-sys/with-fuzzer-no-link"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lmdb-rkv"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Dan Burkert <dan@danburkert.com>", "Victor Porof <vporof@mozilla.com>"]
 license = "Apache-2.0"
 description = "Idiomatic and safe LMDB wrapper."

--- a/README.md
+++ b/README.md
@@ -13,12 +13,28 @@ where LMDB was keeping a lot of pages and not freeing them. So we decided to for
 and add a new `MDB_ALWAYSFREEPAGES` flag to the `MDB_Env` struct. This flag now forces
 LMDB to always free single pages instead of keeping them in a list for future reuse.
 
+## Vendoring
+
+By default, if LMDB is installed on the system, this crate will attempt to make use of the system-available LMDB.
+
+To force installation from source, build this crate with the `vendored` feature.
+
 ## Building from Source
+
+### Using the system LMDB if available
 
 ```bash
 git clone --recursive git@github.com:meilisearch/lmdb-rs.git
 cd lmdb-rs
 cargo build
+```
+
+### Always vendoring
+
+```bash
+git clone --recursive git@github.com:meilisearch/lmdb-rs.git
+cd lmdb-rs
+cargo build --features vendored
 ```
 
 ## Publishing to crates.io

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -32,9 +32,10 @@ bindgen = { version = "0.53.2", default-features = false, optional = true, featu
 
 [features]
 default = []
-with-asan = []
-with-fuzzer = []
-with-fuzzer-no-link = []
+vendored = []
+with-asan = ["vendored",]
+with-fuzzer = ["vendored",]
+with-fuzzer-no-link = ["vendored",]
 
 # These features configure the MDB_IDL_LOGN macro, which determines
 # the size of the free and dirty page lists (and thus the amount of memory

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lmdb-rkv-sys"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Dan Burkert <dan@danburkert.com>", "Victor Porof <vporof@mozilla.com>"]
 license = "Apache-2.0"
 description = "Rust bindings for liblmdb."

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -59,7 +59,9 @@ fn main() {
         warn!("Building with `-fsanitize=fuzzer`.");
     }
 
-    if !pkg_config::find_library("lmdb").is_ok() {
+    let vendored = cfg!(feature = "vendored");
+
+    if vendored || pkg_config::find_library("lmdb").is_err() {
         let mut builder = cc::Build::new();
 
         builder


### PR DESCRIPTION
# Pull Request

## Related issue

Related to https://github.com/meilisearch/meilisearch/issues/3017: will fix once ported to `heed`, `milli` and `meilisearch`.

## What does this PR do?

### User PoV

- Add `vendored` feature to `lmdb-sys` that works similarly to `libgit2` `vendored` feature: when enabled, always use the vendored LMDB instead of the system one, even if it is available.
- Add `vendored` feature to `lmdb-rs`.
- Update README.md to cover the vendoring case.

### Implementation notes

- Made the existing "with-fuzzer", "with-asan", etc. features depend on the "vendored" feature: it does not make sense to attempt to enable e.g. ASAN and then reuse the system LMDB. Previously it would cause a system, non-ASAN enabled LMDB to be used silently if available.
- Bump `lmdb-rs` and `lmdb-sys` versions to 0.15.1

## Tests

Under an up-to-date archlinux:
1. Build the main branch of meilisearch from source
2. Attempt to add index like in the issue, receive an error like in the issue
3. Patch Cargo.toml to use a local heed version
4. Change `heed/Cargo.toml` from the local heed version to use this branch and the vendored feature
5. Rebuild meilisearch, attempt again to create an index: success.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
