### PR TITLE
Bump the LMDB submodule

### DIFF
--- a/lmdb-sys/bindgen.rs
+++ b/lmdb-sys/bindgen.rs
@@ -32,7 +32,7 @@ impl ParseCallbacks for Callbacks {
             | "MDB_BAD_DBI"
             | "MDB_PROBLEM"
             | "MDB_LAST_ERRCODE" => Some(IntKind::Int),
-            "MDB_SIZE_MAX" | "MDB_PROBLEM" => Some(IntKind::ULongLong),
+            "MDB_SIZE_MAX" => Some(IntKind::ULongLong),
             _ => Some(IntKind::UInt),
         }
     }


### PR DESCRIPTION
This PR bumps the LMDB submodule to bring the fixes of [ITS #9806](https://bugs.openldap.org/show_bug.cgi?id=9806) plus our patches. Related to https://github.com/meilisearch/lmdb/pull/1.