### PR TITLE
POSIX semaphores feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tempdir = "0.3"
 [features]
 default = []
 vendored = ["lmdb-rkv-sys/vendored"]
+posix-sem = ["lmdb-rkv-sys/posix-sem"]
 with-asan = ["lmdb-rkv-sys/with-asan"]
 with-fuzzer = ["lmdb-rkv-sys/with-fuzzer"]
 with-fuzzer-no-link = ["lmdb-rkv-sys/with-fuzzer-no-link"]

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -33,6 +33,7 @@ bindgen = { version = "0.53.2", default-features = false, optional = true, featu
 [features]
 default = []
 vendored = []
+posix-sem = ["vendored",]
 with-asan = ["vendored",]
 with-fuzzer = ["vendored",]
 with-fuzzer-no-link = ["vendored",]

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -73,6 +73,10 @@ fn main() {
             .flag_if_supported("-Wbad-function-cast")
             .flag_if_supported("-Wuninitialized");
 
+        if cfg!(feature = "posix-sem") {
+            builder.define("MDB_USE_POSIX_SEM", None);
+        }
+
         if env::var("CARGO_FEATURE_WITH_ASAN").is_ok() {
             builder.flag("-fsanitize=address");
         }


### PR DESCRIPTION
Contributing here instead of Mozilla's `lmdb-rs` because they don't seem like they are accepting PRs in a timely manner. Plus, hopefully this change will be accommodated downstream in `heed` and `milli` as well.

Apple requires applications submitted to the App Store to be sandboxed, and the App Sandbox disallows System V semaphores. Unfortunately, System V semaphores are used by default in LMDB, which proves to be problematic. This PR simply adds a `posix-sem` feature that uses POSIX semaphores instead of System V semaphores.

See here for more: https://github.com/GregoryConrad/mimir/issues/98
